### PR TITLE
Hacky fix for weapon enchants

### DIFF
--- a/src/StatBoostMgr.cpp
+++ b/src/StatBoostMgr.cpp
@@ -361,8 +361,7 @@ bool StatBoostMgr::BoostItem(Player* player, Item* item, uint32 chance)
 
         if (enchantSlot != MAX_ENCHANTMENT_SLOT)
         {
-            return EnchantItem(player, item, enchantSlot, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable) &&
-                EnchantItem(player, item, PRISMATIC_ENCHANTMENT_SLOT, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable);
+            return EnchantItem(player, item, enchantSlot, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable);
         }
     }
 

--- a/src/StatBoostMgr.cpp
+++ b/src/StatBoostMgr.cpp
@@ -372,7 +372,6 @@ bool StatBoostMgr::BoostItem(Player* player, Item* item, uint32 chance)
 EnchantmentSlot StatBoostMgr::GetEnchantSlotForItem(Item* item)
 {
     auto itemTemplate = item->GetTemplate();
-    uint32 itemClass = itemTemplate->Class;
 
     if (!itemTemplate->Socket[0].Color)
     {

--- a/src/StatBoostMgr.cpp
+++ b/src/StatBoostMgr.cpp
@@ -361,7 +361,8 @@ bool StatBoostMgr::BoostItem(Player* player, Item* item, uint32 chance)
 
         if (enchantSlot != MAX_ENCHANTMENT_SLOT)
         {
-            return EnchantItem(player, item, enchantSlot, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable);
+            return EnchantItem(player, item, enchantSlot, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable) &&
+                EnchantItem(player, item, PRISMATIC_ENCHANTMENT_SLOT, 2814, sBoostConfigMgr->OverwriteEnchantEnable);
         }
     }
 

--- a/src/StatBoostMgr.cpp
+++ b/src/StatBoostMgr.cpp
@@ -350,10 +350,20 @@ bool StatBoostMgr::BoostItem(Player* player, Item* item, uint32 chance)
         ChatHandler(player->GetSession()).SendSysMessage("Passed Enchant Check");
     }
 
-    EnchantmentSlot enchantSlot = GetEnchantSlotForItem(item);
-    if (enchantSlot != MAX_ENCHANTMENT_SLOT)
+    
+    if (itemClass != ITEM_CLASS_WEAPON)
     {
-        return EnchantItem(player, item, enchantSlot, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable);
+        return EnchantItem(player, item, TEMP_ENCHANTMENT_SLOT, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable);
+    }
+    else
+    {
+        EnchantmentSlot enchantSlot = GetEnchantSlotForItem(item);
+
+        if (enchantSlot != MAX_ENCHANTMENT_SLOT)
+        {
+            return EnchantItem(player, item, enchantSlot, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable) &&
+                EnchantItem(player, item, PRISMATIC_ENCHANTMENT_SLOT, enchant->Id, sBoostConfigMgr->OverwriteEnchantEnable);
+        }
     }
 
     return false;
@@ -363,11 +373,6 @@ EnchantmentSlot StatBoostMgr::GetEnchantSlotForItem(Item* item)
 {
     auto itemTemplate = item->GetTemplate();
     uint32 itemClass = itemTemplate->Class;
-
-    if (itemClass != ITEM_CLASS_WEAPON)
-    {
-        return TEMP_ENCHANTMENT_SLOT;
-    }
 
     if (!itemTemplate->Socket[0].Color)
     {


### PR DESCRIPTION
A dummy enchant has to be applied to the prismatic slot for the socket enchant to apply.